### PR TITLE
package name added in Package file

### DIFF
--- a/Package
+++ b/Package
@@ -3,6 +3,7 @@
 plugin_name=modbus
 plugin_type=south
 plugin_install_dirname=ModbusC
+plugin_package_name=fledge-${plugin_type}-${plugin_name}
 
 # Now build up the runtime requirements list. This has 3 components
 #   1. Generic packages we depend on in all architectures and package managers


### PR DESCRIPTION
```
$ sudo dpkg -c fledge-south-modbus_2.1.0-3_x86_64.deb 
Password:
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/plugins/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/plugins/south/
drwxrwxr-x ubuntu/ubuntu     0 2023-03-10 15:30 ./usr/local/fledge/plugins/south/ModbusC/
-rw-rw-r-- ubuntu/ubuntu    20 2023-03-10 15:30 ./usr/local/fledge/plugins/south/ModbusC/.Package
-rwxrwxr-x ubuntu/ubuntu 191592 2023-03-10 15:30 ./usr/local/fledge/plugins/south/ModbusC/libModbusC.so.1
lrwxrwxrwx ubuntu/ubuntu      0 2023-03-10 15:30 ./usr/local/fledge/plugins/south/ModbusC/libModbusC.so -> libModbusC.so.1
```

API results:
```
{
      "name": "ModbusC",
      "type": "south",
      "description": "Modbus TCP and RTU C south plugin",
      "version": "2.1.0-3-g8aaf7c4",
      "installedDirectory": "south/ModbusC",
      "packageName": "fledge-south-modbus"
    },
```